### PR TITLE
fix: mlflow-sqlite-mlruns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,5 +165,5 @@ data.lock
 lance_db
 lightning_logs
 megalinter-reports
-mlruns
+mlruns.db
 ray_results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,5 +54,5 @@ builds a LanceDB index, and registers the model in BentoML.
 - **Linter / formatter:** `ruff` — `ALL` rules selected; `D`, `E501`, `S101`, `T201`, `COM812`, `ERA001`,
   `ISC001`, `PLC0415` ignored
 - **Pre-commit hooks:** ruff, taplo (TOML), yamlfmt, markdownlint-cli2, shfmt, shellcheck, hadolint, gitleaks, uv-lock
-- **Experiment tracking:** MLflow + TensorBoard (logs in `mlruns/` and `lightning_logs/`)
+- **Experiment tracking:** MLflow + TensorBoard (logs in `mlruns.db` and `lightning_logs/`)
 - **Container:** `Dockerfile` + `compose.yaml`; image at `ghcr.io/yxtay/transformer-recommenders`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ on MovieLens data, with scalable data access and experiment tracking.
   - `data/`: Raw and processed MovieLens datasets (Parquet format)
   - `lance_db/`: LanceDB format for fast retrieval
 - **Experiment Logs:**
-  - `lightning_logs/`, `mlruns/`: Model checkpoints and experiment tracking (MLflow)
+  - `lightning_logs/`, `mlruns.db`: Model checkpoints and experiment tracking (MLflow)
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "lancedb[pylance]>=0.19,<1.0",
   "lightning~=2.6",
   "loguru>=0.7,<1.0",
-  "mlflow-skinny~=3.1",
+  "mlflow~=3.1",
   "polars[pandas]~=1.19",
   "pydantic-settings~=2.14",
   "sentence-transformers[onnx,train]~=5.0",
@@ -31,7 +31,6 @@ dependencies = [
 dev = [
   "flaml[automl,blendsearch]~=2.3",
   "huggingface-hub[cli]>=0.35",
-  "mlflow",
   "pyarrow-stubs>=20.0",
   "pytest~=9.0",
   "standard-imghdr~=3.13",

--- a/uv.lock
+++ b/uv.lock
@@ -4022,7 +4022,7 @@ dependencies = [
     { name = "lancedb", extra = ["pylance"] },
     { name = "lightning" },
     { name = "loguru" },
-    { name = "mlflow-skinny" },
+    { name = "mlflow" },
     { name = "polars", extra = ["pandas"] },
     { name = "pydantic-settings" },
     { name = "sentence-transformers", extra = ["onnx", "train"] },
@@ -4035,7 +4035,6 @@ dependencies = [
 dev = [
     { name = "flaml", extra = ["automl", "blendsearch"] },
     { name = "huggingface-hub", extra = ["cli"] },
-    { name = "mlflow" },
     { name = "pyarrow-stubs" },
     { name = "pytest" },
     { name = "standard-imghdr" },
@@ -4050,7 +4049,7 @@ requires-dist = [
     { name = "lancedb", extras = ["pylance"], specifier = ">=0.19,<1.0" },
     { name = "lightning", specifier = "~=2.6" },
     { name = "loguru", specifier = ">=0.7,<1.0" },
-    { name = "mlflow-skinny", specifier = "~=3.1" },
+    { name = "mlflow", specifier = "~=3.1" },
     { name = "polars", extras = ["pandas"], specifier = "~=1.19" },
     { name = "pydantic-settings", specifier = "~=2.14" },
     { name = "sentence-transformers", extras = ["onnx", "train"], specifier = "~=5.0" },
@@ -4062,7 +4061,6 @@ requires-dist = [
 dev = [
     { name = "flaml", extras = ["automl", "blendsearch"], specifier = "~=2.3" },
     { name = "huggingface-hub", extras = ["cli"], specifier = ">=0.35" },
-    { name = "mlflow" },
     { name = "pyarrow-stubs", specifier = ">=20.0" },
     { name = "pytest", specifier = "~=9.0" },
     { name = "standard-imghdr", specifier = "~=3.13" },

--- a/xfmr_rec/trainer.py
+++ b/xfmr_rec/trainer.py
@@ -440,7 +440,7 @@ class LightningCLI:
             "init_args": {
                 "experiment_name": model_name,
                 "run_name": run_name,
-                "tracking_uri": "sqlite:///mlruns.db",
+                "tracking_uri": mlflow.get_tracking_uri(),
                 "run_id": run_id,
                 "log_model": log_model,
             },

--- a/xfmr_rec/trainer.py
+++ b/xfmr_rec/trainer.py
@@ -440,6 +440,7 @@ class LightningCLI:
             "init_args": {
                 "experiment_name": model_name,
                 "run_name": run_name,
+                "tracking_uri": "sqlite:///mlruns.db",
                 "run_id": run_id,
                 "log_model": log_model,
             },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated experiment tracking to use local, file-based MLflow storage backed by an `mlruns.db` SQLite database for more consistent run metadata and metrics access.
  * Updated MLflow logging behavior to respect the current MLflow tracking URI when configuring runs.
  * Adjusted dependency configuration to use the full `mlflow` package.
* **Documentation**
  * Updated guidance and README references to point to `mlruns.db` (instead of the previous `mlruns/` path).
* **Style**
  * Updated version control rules to ignore `mlruns.db` while keeping existing log directories unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->